### PR TITLE
Reflection Changed to have two Build Outputs (native games and extended engine)

### DIFF
--- a/ConsoleGames/BasicGameInterface/AbstractGame.csproj
+++ b/ConsoleGames/BasicGameInterface/AbstractGame.csproj
@@ -30,6 +30,24 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'NativeGames|AnyCPU'">
+    <OutputPath>bin\NativeGames\</OutputPath>
+    <DefineConstants>TRACE;INCLUDE_NATIVE_GAMES</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'DLLGames|AnyCPU'">
+    <OutputPath>bin\DLLGames\</OutputPath>
+    <DefineConstants>TRACE;ENABLE_REFLECTION</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -46,4 +64,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>
+    </PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/ConsoleGames/GameEngine.sln
+++ b/ConsoleGames/GameEngine.sln
@@ -3,24 +3,33 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33801.468
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GamePlatform", "GamePlatform\GamePlatform.csproj", "{E994050B-8116-453A-AFB8-237B67B4EFCA}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AbstractGame", "BasicGameInterface\AbstractGame.csproj", "{FB3243D7-B17C-421F-B1F0-90CA589DE78B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GameEngine", "GameEngine\GameEngine.csproj", "{E994050B-8116-453A-AFB8-237B67B4EFCA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		DLLGames|Any CPU = DLLGames|Any CPU
+		NativeGames|Any CPU = NativeGames|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{E994050B-8116-453A-AFB8-237B67B4EFCA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E994050B-8116-453A-AFB8-237B67B4EFCA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E994050B-8116-453A-AFB8-237B67B4EFCA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E994050B-8116-453A-AFB8-237B67B4EFCA}.Release|Any CPU.Build.0 = Release|Any CPU
 		{FB3243D7-B17C-421F-B1F0-90CA589DE78B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FB3243D7-B17C-421F-B1F0-90CA589DE78B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FB3243D7-B17C-421F-B1F0-90CA589DE78B}.DLLGames|Any CPU.ActiveCfg = DLLGames|Any CPU
+		{FB3243D7-B17C-421F-B1F0-90CA589DE78B}.DLLGames|Any CPU.Build.0 = DLLGames|Any CPU
+		{FB3243D7-B17C-421F-B1F0-90CA589DE78B}.NativeGames|Any CPU.ActiveCfg = NativeGames|Any CPU
 		{FB3243D7-B17C-421F-B1F0-90CA589DE78B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FB3243D7-B17C-421F-B1F0-90CA589DE78B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E994050B-8116-453A-AFB8-237B67B4EFCA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E994050B-8116-453A-AFB8-237B67B4EFCA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E994050B-8116-453A-AFB8-237B67B4EFCA}.DLLGames|Any CPU.ActiveCfg = DLLGames|Any CPU
+		{E994050B-8116-453A-AFB8-237B67B4EFCA}.DLLGames|Any CPU.Build.0 = DLLGames|Any CPU
+		{E994050B-8116-453A-AFB8-237B67B4EFCA}.NativeGames|Any CPU.ActiveCfg = NativeGames|Any CPU
+		{E994050B-8116-453A-AFB8-237B67B4EFCA}.NativeGames|Any CPU.Build.0 = NativeGames|Any CPU
+		{E994050B-8116-453A-AFB8-237B67B4EFCA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E994050B-8116-453A-AFB8-237B67B4EFCA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ConsoleGames/GameEngine/ConsoleEngine.cs
+++ b/ConsoleGames/GameEngine/ConsoleEngine.cs
@@ -29,14 +29,65 @@ namespace GameEngine
         }
         private ConsoleGame SelectGame()
         {
-            Type game = SelectGameMenuType();
+            Type game = NativeSelectGameMenuType();
+#if INCLUDE_NATIVE_GAMES
+                 game = NativeSelectGameMenuType();
+#elif ENABLE_REFLECTION
+                 game = ReflectionSelectGameMenuType();
+#endif
+
             return (ConsoleGame)Activator.CreateInstance(game);
         }
-        private Type SelectGameMenuType()
+        private Type ReflectionSelectGameMenuType()
         {
             char response = ' ';
             StringBuilder SelectGameMenuBuilder = new StringBuilder(SELECT_GAME_MENU).AppendLine();
             List<(Type type, string Name)> types = GetDLLTypes();
+
+            types.AddRange(Assembly.GetExecutingAssembly()
+                                   .GetTypes()
+                                   .Where(typeWhere => typeWhere.IsSubclassOf(typeof(ConsoleGame)))
+                                   .Select(typeSelect => (typeSelect, typeSelect.GetCustomAttribute<GameNameAttribute>()?.Name ?? typeSelect.Name)));
+            if (types.Count == 0)
+            {
+                Console.WriteLine("No games found. Press any key to exit.");
+                Console.ReadKey();
+                Environment.Exit(0);
+            }
+            for (int i = 0; i < types.Count; i++)
+            {
+                SelectGameMenuBuilder.AppendLine($"{(char)('a' + i)}. {types[i].Name} ");
+            }
+            SelectGameMenuBuilder.AppendLine(EXIT_MENU_OPTION_KEY + ". " + EXIT_MENU_OPTION);
+            Console.SetCursorPosition(SELECT_GAME_MENU_C.left, SELECT_GAME_MENU_C.top);
+            Console.WriteLine(SelectGameMenuBuilder.ToString());
+            Console.SetCursorPosition(SELECT_GAME_INPUT.left, SELECT_GAME_INPUT.top);
+            while (true)
+            {
+                response = Console.ReadKey(true).KeyChar;
+                if (response == EXIT_MENU_OPTION_KEY[0])
+                {
+                    Environment.Exit(0);
+                }
+                if (response >= 'a' && response <= 'z' && response - 'a' < types.Count)
+                {
+                    break;
+                }
+                // invalid input
+                Console.SetCursorPosition(SELECT_GAME_MENU_C.left, SELECT_GAME_MENU_C.top);
+                Console.WriteLine(SelectGameMenuBuilder.ToString());
+                Console.SetCursorPosition(SELECT_GAME_INPUT.left, SELECT_GAME_INPUT.top);
+            }
+            return types[response - 'a'].type;
+        }
+        private Type NativeSelectGameMenuType()
+        {
+            char response = ' ';
+            StringBuilder SelectGameMenuBuilder = new StringBuilder(SELECT_GAME_MENU).AppendLine();
+            List<(Type type, string Name)> types = new List<(Type type, string Name)>(Assembly.GetExecutingAssembly()
+                                                                                              .GetTypes()
+                                                                                              .Where(typeWhere => typeWhere.IsSubclassOf(typeof(ConsoleGame)))
+                                                                                              .Select(typeSelect => (typeSelect, typeSelect.GetCustomAttribute<GameNameAttribute>()?.Name ?? typeSelect.Name)));
             if (types.Count == 0)
             {
                 Console.WriteLine("No games found. Press any key to exit.");
@@ -88,7 +139,6 @@ namespace GameEngine
         private List<(Type type, string Name)> GetDLLTypes()
         {
             List<Assembly> assemblies = LoadAllDLLAssemblies();
-            assemblies.Add(Assembly.GetExecutingAssembly());
 
             var gameTypes = assemblies.SelectMany(assembly => assembly.GetTypes())
                           .Where(typeWhere => typeWhere.IsSubclassOf(typeof(ConsoleGame)))

--- a/ConsoleGames/GameEngine/FodyWeavers.xml
+++ b/ConsoleGames/GameEngine/FodyWeavers.xml
@@ -1,0 +1,3 @@
+﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
+  <Costura />
+</Weavers>

--- a/ConsoleGames/GameEngine/GameEngine.csproj
+++ b/ConsoleGames/GameEngine/GameEngine.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Costura.Fody.5.7.0\build\Costura.Fody.props" Condition="Exists('..\packages\Costura.Fody.5.7.0\build\Costura.Fody.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -12,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -32,20 +35,173 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'NativeGames|AnyCPU'">
+    <OutputPath>bin\NativeGames\</OutputPath>
+    <DefineConstants>TRACE;INCLUDE_NATIVE_GAMES</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'DLLGames|AnyCPU'">
+    <OutputPath>bin\DLLGames\</OutputPath>
+    <DefineConstants>TRACE;ENABLE_REFLECTION</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Costura, Version=5.7.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Costura.Fody.5.7.0\lib\netstandard1.0\Costura.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Build" />
     <Reference Include="Microsoft.Build.Tasks.v4.0" />
+    <Reference Include="Microsoft.Win32.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Win32.Primitives.4.3.0\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.AppContext, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.AppContext.4.3.0\lib\net463\System.AppContext.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Console, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Console.4.3.0\lib\net46\System.Console.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.3.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Diagnostics.Tracing, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.Tracing.4.3.0\lib\net462\System.Diagnostics.Tracing.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Globalization.Calendars, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Globalization.Calendars.4.3.0\lib\net46\System.Globalization.Calendars.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.4.3.0\lib\net462\System.IO.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.Compression, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Compression.4.3.0\lib\net46\System.IO.Compression.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.IO.Compression.ZipFile, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Compression.ZipFile.4.3.0\lib\net46\System.IO.Compression.ZipFile.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.FileSystem, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.FileSystem.4.3.0\lib\net46\System.IO.FileSystem.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Linq, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Linq.4.3.0\lib\net463\System.Linq.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Linq.Expressions, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Linq.Expressions.4.3.0\lib\net463\System.Linq.Expressions.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.Http.4.3.0\lib\net46\System.Net.Http.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Sockets, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.Sockets.4.3.0\lib\net46\System.Net.Sockets.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Reflection, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.4.3.0\lib\net462\System.Reflection.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.4.3.0\lib\net462\System.Runtime.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.Extensions, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.Extensions.4.3.0\lib\net462\System.Runtime.Extensions.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.InteropServices, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.4.3.0\lib\net463\System.Runtime.InteropServices.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net463\System.Security.Cryptography.Algorithms.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Text.RegularExpressions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.RegularExpressions.4.3.0\lib\net463\System.Text.RegularExpressions.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.ReaderWriter, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.ReaderWriter.4.3.0\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="GamesEngine.cs" />
+    <Compile Include="ConsoleEngine.cs" />
     <Compile Include="Games\TikTacToeEngine.cs" />
     <Compile Include="Games\_2048Engine.cs" />
     <Compile Include="Program.cs" />
@@ -54,6 +210,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BasicGameInterface\AbstractGame.csproj">
@@ -62,4 +219,14 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Fody.6.5.5\build\Fody.targets" Condition="Exists('..\packages\Fody.6.5.5\build\Fody.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Fody.6.5.5\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.6.5.5\build\Fody.targets'))" />
+    <Error Condition="!Exists('..\packages\Costura.Fody.5.7.0\build\Costura.Fody.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Costura.Fody.5.7.0\build\Costura.Fody.props'))" />
+    <Error Condition="!Exists('..\packages\Costura.Fody.5.7.0\build\Costura.Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Costura.Fody.5.7.0\build\Costura.Fody.targets'))" />
+  </Target>
+  <Import Project="..\packages\Costura.Fody.5.7.0\build\Costura.Fody.targets" Condition="Exists('..\packages\Costura.Fody.5.7.0\build\Costura.Fody.targets')" />
 </Project>

--- a/ConsoleGames/GameEngine/packages.config
+++ b/ConsoleGames/GameEngine/packages.config
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Costura.Fody" version="5.7.0" targetFramework="net472" developmentDependency="true" />
+  <package id="Fody" version="6.5.5" targetFramework="net472" developmentDependency="true" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net472" />
+  <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net472" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net472" />
+  <package id="System.AppContext" version="4.3.0" targetFramework="net472" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net472" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net472" />
+  <package id="System.Console" version="4.3.0" targetFramework="net472" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net472" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.3.0" targetFramework="net472" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net472" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net472" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net472" />
+  <package id="System.Globalization.Calendars" version="4.3.0" targetFramework="net472" />
+  <package id="System.IO" version="4.3.0" targetFramework="net472" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net472" />
+  <package id="System.IO.Compression.ZipFile" version="4.3.0" targetFramework="net472" />
+  <package id="System.IO.FileSystem" version="4.3.0" targetFramework="net472" />
+  <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net472" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net472" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net472" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net472" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net472" />
+  <package id="System.Net.Sockets" version="4.3.0" targetFramework="net472" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net472" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net472" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net472" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net472" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net472" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net472" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net472" />
+  <package id="System.Runtime.Handles" version="4.3.0" targetFramework="net472" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net472" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net472" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net472" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net472" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net472" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net472" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net472" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net472" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net472" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net472" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net472" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net472" />
+  <package id="System.Threading.Timer" version="4.3.0" targetFramework="net472" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net472" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net472" />
+</packages>


### PR DESCRIPTION
pulled reflection into a separate build EXE to enable a single output EXE for native games (added Costura.Fody to merge AbstractGame DLL into main EXE)